### PR TITLE
Add dice type ±dX

### DIFF
--- a/dice/elements.py
+++ b/dice/elements.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import random
 import operator
 
-from dice.utilities import classname
+from dice.utilities import classname, addevensubodd
 
 
 class Element(object):
@@ -140,6 +140,10 @@ class Sub(IntegerOperator):
 
 class Add(IntegerOperator):
     function = operator.add
+
+
+class AddEvenSubOdd(IntegerOperator):
+    function = addevensubodd
 
 
 class Total(Operator):

--- a/dice/grammar.py
+++ b/dice/grammar.py
@@ -13,7 +13,7 @@ from pyparsing import (
     Suppress, Word, nums, opAssoc)
 
 from dice.elements import (
-    Integer, Dice, Mul, Div, Sub, Add, Total, Sort, Drop, Keep)
+    Integer, Dice, Mul, Div, Sub, Add, AddEvenSubOdd, Total, Sort, Drop, Keep)
 from dice.utilities import patch_pyparsing
 
 patch_pyparsing()
@@ -90,6 +90,8 @@ expression = StringStart() + operatorPrecedence(integer, [
     (Literal('*').suppress(), 2, opAssoc.LEFT, Mul.parse),
     (Literal('-').suppress(), 2, opAssoc.LEFT, Sub.parse),
     (Literal('+').suppress(), 2, opAssoc.LEFT, Add.parse),
+    (Word('+-').suppress(), 1, opAssoc.RIGHT, AddEvenSubOdd.parse),
+    (Word('+-').suppress(), 2, opAssoc.LEFT, AddEvenSubOdd.parse),
 
     (CaselessLiteral('t').suppress(), 1, opAssoc.LEFT, Total.parse),
     (CaselessLiteral('s').suppress(), 1, opAssoc.LEFT, Sort.parse),

--- a/dice/utilities.py
+++ b/dice/utilities.py
@@ -45,3 +45,15 @@ def disable_pyparsing_arity_trimming():
     very hard to do."""
     warnings.warn("Disabled pyparsing arity trimming", ImportWarning)
     pyparsing._trim_arity = _trim_arity
+
+
+def addevensubodd(name="", a=0, b=0, *args, **kwds):
+    """Add even numbers, subtract odd ones. See http://1w6.org/w6 """
+    def _subodd(a):
+        if a % 2:
+            return - a
+        else:
+            return a
+    if b:
+        return a + _subodd(b)
+    return _subodd(a)


### PR DESCRIPTION
The ±dX is a die type where even numbers are treated as positive and odd numbers are treated as negative. The ±d6 is used in the 1d6 RPG ( see http://1w6.org ).