### PR TITLE
Fix for Issue #3 - Multipe operation error

### DIFF
--- a/dice/elements.py
+++ b/dice/elements.py
@@ -113,8 +113,14 @@ class Operator(Element):
             classname(self), ', '.join(map(str, self.orginal_operands)))
 
     def evaluate(self):
-        self.operands = map(self.evaluate_object, self.operands)
-        return self.function(*self.operands)
+        self.operands = list(map(self.evaluate_object, self.operands))
+        try:
+            return self.function(*self.operands)
+        except TypeError:
+            value = self.operands[0]
+            for o in self.operands[1:]:
+                value = self.function(value, o)
+            return value
 
     @property
     def function(self):

--- a/dice/tests/test_elements.py
+++ b/dice/tests/test_elements.py
@@ -28,3 +28,10 @@ class TestEvaluate(object):
         roll('6d(6d6)t')
         ast = Total(Dice(6, Dice(6, 6)))
         assert ast.evaluate_cached() is ast.evaluate_cached()
+
+    def test_multiargs(self):
+        """Test that binary operators function properly when repeated"""
+        assert roll('1d1+1d1+1d1') == 3
+        assert roll('1d1-1d1-1d1') == -1
+        assert roll('1d1*1d1*1d1') == 1
+        assert roll('1d1/1d1/1d1') == 1


### PR DESCRIPTION
Handles the TypeError raised in an Operator's evaluate method when too many arguments are passed into that Operator's function.  In these cases (e. g. for Python builtin operators), the appropriate function is applied pairwise to operands in order to accomplish the same calculation without triggering a TypeError.