### PR TITLE
Just some things I added that people might find useful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,30 @@
 # https://travis-ci.org/borntyping/python-dice
 
 language: python
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35  
-  - TOXENV=pypy
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
+    - python: 2.7
+      env: TOXENV=py27-pep8
+    - python: 2.7
+      env: TOXENV=py27-pyflakes
+    - python: 2.7
+      env: TOXENV=py27-coverage
 install:
   - pip install tox
 script:

--- a/README.rst
+++ b/README.rst
@@ -9,56 +9,142 @@ dice
 .. image:: https://travis-ci.org/borntyping/python-dice.png
     :target: https://travis-ci.org/borntyping/python-dice
     :alt: Travis-CI build status
-           
 
 A library and command line tool for parsing and evaluating dice notation.
 
 Usage
 =====
 
-From the command line::
+From the command line, as a pip-installed entry point::
 
-    roll 3d6
+    $ roll 3d6
 
-From python::
+or as a module::
+
+    $ python -m dice 3d6
+
+The command line arguments are as follows::
+
+    -m --min        Make all rolls the lowest possible result
+    -M --max        Make all rolls the highest possible result
+    -h --help       Show this help text
+    -v --verbose    Show additional output
+    -V --version    Show the package version
+
+If your expression begins with a dash (``-``), then put a double dash (``--``)
+before it to prevent docopt from trying to process it as a command option.
+Example: ``roll -- -10d6``. Alternatively, use parenthesis: ``roll (-10d6)``.
+
+Invoking from python::
 
     import dice
     dice.roll('3d6')
+
+This returns an ``Element`` which is the result of the roll, which can be a
+``list``, ``int``, or subclass thereof, depending on the top-level operator.
 
 Notation
 ========
 
 The expression works like a simple equation parser with some extra operators.
 
-*The following operators are listed in order of precedence.*
+*The following operators are listed in order of precedence. Parentheses may
+be used to force an alternate order of evaluation.*
 
-The dice ('d') operator takes an amount (A) and a number of sides (S), and
-returns a list of A random numbers between 1 and S. For example: ``4d6`` may
-return ``[6, 3, 2, 4]``.
+The dice (``[N]dS``) operator takes an amount (N) and a number of sides (S), and
+returns a list of N random numbers between 1 and S. For example: ``4d6`` may
+return ``[6, 3, 2, 4]``. Usin a ``%`` as the second operand is shorthand for 
+rolling a d100, and a using ``f`` is shorthand for ±1 fudge dice.
 
-If A is not specified, it is assumed you want to roll a single die.
+The fudge dice (``[N]uS``) operator is interchangable with the dice operator,
+but makes the dice's range from -S to S instead of 1 to S. This includes 0.
+
+A wild dice (``[N]wS``) roll is special. The last roll in this set is called the
+"wild die". If this die's roll is the maximum value, the second-highest roll
+in the set is set to the maximum value. If its roll is the minimum, then
+both it and the highest roll in the set aer set to zero. Then another die is
+rolled. If this roll is the minimum value again, then ALL die are set to zero.
+
+If N is not specified, it is assumed you want to roll a single die.
 ``d6`` is equivalent to ``1d6``.
 
-Basic integer operations are available: ``16 / 8 * 4 + 2 - 1 -> 9``.
+Rolls can be exploded with the ``x`` operator, which adds an additional dice
+to the set for each roll above a given threshold. If a threshold isn't given,
+it defaults to the maximum possible roll. If the extra dice exceed this
+threshold, they "explode" again! Safeguards are in place to prevent this from
+crashing the parser with infinite explosions.
 
-A set of rolls can be turned into an integer with the total (``t``) operator.
-``6d1t`` will return ``6`` instead of ``[1, 1, 1, 1, 1, 1]``. Applying
-integer operations to a list of rolls will total them automatically.
+You can make the parser reroll dice below a certain threshold with the ``r``
+and ``rr`` operators. The single ``r`` variety allows the new roll to be below
+the threshold, whereas the double variety's roll *changes* the roll range to
+have a minimum of the threshold. The threshold defaults to the minimum roll.
+
+The highest, middle or lowest rolls or list entries can be selected with
+(``^`` or ``h``), (``m`` or ``o``), or (``v`` or ``l``) respectively.
+``6d6^3`` will keep the highest 3 rolls, whereas ``6d6v3`` will select
+the lowest 3 rolls. If a number isn't specified, it defaults to keeping all
+but one for highest and lowest, and all but two for the middle.
+
+There are two operators for taking a set of rolls or numbers and counting the
+number of elements at or above a certain threshold, or "successes". Both
+require a right-hand operand for the threshold. The first, ``e``, only counts
+successes. The second, ``f``, counts successes minus failures, which are when
+a roll is the minimum possible value for the die element, or 1 for lists.
+
+The ``+-`` operator is a special prefix for sets of rolls and lists. It
+negates odd roles within a list. Example: ``[1, 2, 3]`` -> ``[-1, 2, -3]``.
+There is also the negate (``-``) operator, which works on either single
+elements, sets or rolls, or lists. There is also an identity ``+`` operator.
+
+A list or set of rolls can be turned into an integer with the total (``t``)
+operator. ``6d1t`` will return ``6`` instead of ``[1, 1, 1, 1, 1, 1]``.
+Applying integer operations to a list of rolls will total them automatically.
 
 A set of dice rolls can be sorted with the sort (``s``) operator. ``4d6s``
 will not change the return value, but the dice will be sorted from lowest to
 highest.
 
-The lowest or highest rolls can be selected with ``^`` and ``v``. ``6d6^3``
-will keep the highest 3 rolls, whereas ``6d6v3`` will select the lowest 3
-rolls.
+Values can be added or subtracted from each element of a list or set of rolls
+with the pointwise add (``.+``) and subtract (``.-``) operators. For example:
+``4d1 .+ 3`` will return ``[4, 4, 4, 4]``.
+
+Basic integer operations are also available: ``16 / 8 * 4 - 2 + 1 -> 9``.
+
+
+Finally, there are two operators for building and extending lists. To build a
+list, use a comma to seperate elements. If any comma-seperated item isn't a
+scalar (e.g. a  roll), it is flattened into one by taking its total. The
+extend operator (``|``) is used to merge two lists into one, or append single
+elements to the beginning or end of a list.
+
+API
+===
+
+The calls to ``dice.roll()`` above may be replaced with ``dice.roll_min()`` or
+``dice.roll_max()`` to force ALL rolls to their highest or lowest values
+respectively. This might be useful to see what the minumum and maximum
+possible values for a given expression are. Beware that this causes wild dice
+rolls to act like normal ones, and rolls performed as explosions are not
+forced high or low.
+
+The ``roll()`` function and variants take a boolean ``raw`` parameter which
+makes the library return the element instead of the result. Note that the 
+``evaluate_cached`` method is called as part of ``roll()``, which populates
+``element.result``. Calling ``element.evaluate()`` will not reset this value.
+
+To display a verbose breakdown of the element tree, the
+``dice.utilities.verbose_print(element)`` function is available.
+If ``element.result`` has not yet been populated, the function calls
+``evaluate_cached()`` first. Keep this in mind if you want to print the result
+of an evaluation with custom arguments. ``verbose_print()`` returns a ``str``.
+
 
 Licence
 =======
 
 The MIT License (MIT)
 
-Copyright (c) 2013 Sam Clements
+Copyright (c) 2013 Sam Clements, 2017 Caleb Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/dice/__init__.py
+++ b/dice/__init__.py
@@ -3,22 +3,45 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from pyparsing import ParseException
+from dice.elements import TooManyDice
 
 import dice.elements
 import dice.grammar
 import dice.utilities
 
-__all__ = ['roll', 'ParseException']
-__author__ = "Sam Clements <sam@borntyping.co.uk>"
-__version__ = '1.1.1'
+__all__ = ['roll', 'roll_min', 'roll_max', 'ParseException', 'TooManyDice']
+__author__ = ("Sam Clements <sam@borntyping.co.uk>, "
+              "Caleb Johnson <me@calebj.io>")
+__version__ = '1.2.0'
 
 
-def roll(string, single=True, verbose=False):
+def roll(string, **kwargs):
     """Parses and evaluates a dice expression"""
-    ast = dice.grammar.expression.parseString(string, parseAll=True)
-    if verbose:
-        dice.elements.Element.verbose = True
-    result = [element.evaluate_cached(verbose=verbose) for element in ast]
+    return _roll(string, **kwargs)
+
+
+def roll_min(string, **kwargs):
+    """Parses and evaluates the minimum of a dice expression"""
+    return _roll(string, force_extreme=dice.elements.EXTREME_MIN, **kwargs)
+
+
+def roll_max(string, **kwargs):
+    """Parses and evaluates the maximum of a dice expression"""
+    return _roll(string, force_extreme=dice.elements.EXTREME_MAX, **kwargs)
+
+
+def parse_expression(string):
+    return dice.grammar.expression.parseString(string, parseAll=True)
+
+
+def _roll(string, single=True, raw=False, **kwargs):
+    ast = parse_expression(string)
+    elements = list(ast)
+    result = [element.evaluate_cached(**kwargs) for element in elements]
+
+    ret = elements if raw else result
+
     if single:
-        return dice.utilities.single(result)
-    return result
+        return dice.utilities.single(ret)
+
+    return ret

--- a/dice/__main__.py
+++ b/dice/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import sys
+import dice.command
+
+if __name__ == '__main__':
+    dice.command.main(sys.argv[1:])

--- a/dice/command.py
+++ b/dice/command.py
@@ -1,8 +1,10 @@
 """
 Usage:
-    roll [--verbose] <expression>
+    roll [--verbose] [--min | --max] [--] <expression>...
 
 Options:
+    -m --min        Make all rolls the lowest possible result
+    -M --max        Make all rolls the highest possible result
     -h --help       Show this help text
     -v --verbose    Show additional output
     -V --version    Show the package version
@@ -20,7 +22,23 @@ __version__ = "dice v{0} by {1}".format(dice.__version__, dice.__author__)
 def main(argv=None):
     """Run roll() from a command line interface"""
     args = docopt.docopt(__doc__, argv=argv, version=__version__)
-    result = dice.roll(args['<expression>'], verbose=args['--verbose'])
-    if args['--verbose']:
-        print("Result:", end=" ")
-    print(str(result))
+    verbose = bool(args['--verbose'])
+
+    f_roll = dice.roll
+
+    if args['--min']:
+        f_roll = dice.roll_min
+    elif args['--max']:
+        f_roll = dice.roll_max
+
+    expr = ' '.join(args['<expression>'])
+    roll = f_roll(expr, raw=True)
+
+    if verbose:
+        print('Result: ', end=" ")
+
+    print(str(roll.evaluate_cached()))
+
+    if verbose:
+        print('Breakdown:')
+        print(dice.utilities.verbose_print(roll))

--- a/dice/tests/test_command.py
+++ b/dice/tests/test_command.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import
 
 import itertools
-
-from dice import roll
+from dice import roll, roll_min, roll_max
 from dice.command import main
 
 
 def test_roll():
-    for single, verbose in itertools.product((True, False), (True, False)):
-        assert roll('6d6', single=single, verbose=verbose)
+    for single, raw in itertools.product((True, False), (True, False)):
+        assert roll('6d6', single=single, raw=raw)
+        assert roll_min('6d6', single=single, raw=raw)
+        assert roll_max('6d6', single=single, raw=raw)
 
 
 def test_main(capsys):

--- a/dice/tests/test_elements.py
+++ b/dice/tests/test_elements.py
@@ -1,12 +1,20 @@
 from __future__ import absolute_import
 
-from dice.elements import Integer, Roll, Dice, Total
-from dice import roll
+from pyparsing import ParseException, ParseFatalException
+from py.test import raises
+
+from dice.elements import (Integer, Roll, WildRoll, Dice, FudgeDice, Total,
+                           MAX_ROLL_DICE, TooManyDice)
+from dice import roll, roll_min, roll_max
 
 
 class TestElements(object):
     def test_integer(self):
         assert isinstance(Integer(1), int)
+
+    def test_dice_construct(self):
+        d = Dice(2, 6)
+        assert d.amount == 2 and d.amount == 2 and d.sides == d.max_value == 6
 
     def test_dice_from_iterable(self):
         d = Dice.from_iterable((2, 6))
@@ -18,8 +26,43 @@ class TestElements(object):
 
     def test_roll(self):
         amount, sides = 6, 6
-        assert len(Roll.roll(amount, sides)) == amount
-        assert (1 * sides) <= sum(Roll.roll(amount, sides)) <= (amount * sides)
+        assert len(Roll.roll(amount, 1, sides)) == amount
+        rr = Roll.roll(amount, 1, sides)
+        assert (1 * sides) <= sum(rr) <= (amount * sides)
+
+    def test_list(self):
+        assert roll('1, 2, 3') == [1, 2, 3]
+
+    def test_special_rhs(self):
+        assert roll('d%', raw=True).max_value == 100
+        fudge = roll('dF', raw=True)
+        assert fudge.min_value == -1 and fudge.max_value == 1
+
+    def test_extreme_roll(self):
+        assert roll_min('3d6') == [1] * 3
+        assert roll_max('3d6') == [6] * 3
+
+    def test_fudge(self):
+        amount, _range = 6, 6
+        fdice = FudgeDice(amount, _range)
+        assert fdice.min_value == -_range and fdice.max_value == _range
+        froll = fdice.evaluate()
+        assert len(froll) == amount
+        assert -(amount * _range) <= sum(froll) <= (amount * _range)
+
+    def test_wild(self):
+        amount, sides = 6, 6
+        assert len(WildRoll.roll(amount, 1, sides)) >= amount
+        rr = WildRoll.roll(amount, 1, sides)
+        assert 0 <= sum(rr)
+
+
+class TestErrors(object):
+    exc_types = (ParseException, ParseFatalException)
+
+    def test_toomanydice(self):
+        with raises(TooManyDice):
+            roll('%id6' % (MAX_ROLL_DICE + 1))
 
 
 class TestEvaluate(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 minversion=1.5.0
 toxworkdir=.cache
-envlist=py27-pyflakes,py27-pep8,py26,py27,py33,py34,py35,pypy
+envlist=py27-pyflakes,py27-pep8,py27-coverage,py26,py27,py33,py34,py35,py36,py37,pypy,pypy3
+skip_missing_interpreters=true
 
 [testenv]
 commands=py.test dice


### PR DESCRIPTION
* Wild dice (`NwS`): Last die rolled is the "wild die". If its last roll is...
  * max: explode recursively
  * min: set and the highest value to the lowest possible, then reroll. If min again, critfail (all min).
* Fudge dice (`dF` for range of -1 to 1, `NuR` for range of -R to R)
* Percentile dice (`d%`) shortcut
* Additional operators (all case insensitive):
  * Successes (`e`)
  * Successes minus failures (`f`)
  * Middle (`o`, `m`)
    * Defaults to dropping single highest and lowest.
  * Unary negative and positive
    * Handles stray `+` signs
    * Unary negative operates on both vectors or scalars
  * Explode (`x`), reroll (`r`) and recursive reroll (`rr`)
    * Requested in borntyping/python-dice#8
    * Operand defaults to max and min respectively
  * Multiple rolls (`,`)
    * Coerces operands to scalars
  * Build vector / "concatenate" (`|`)
    * Coerces/encapsulates operands into a vector
  * Pointwise add/subtract (`.+`, `.-`)
    * adds or subtracts from all elements. `[1, 2, 3] .+ 4` => `[5, 6, 7]`
* Expose min and max possible result of rolls
* Roll result introspection/breakdown via command line and API
  * Can output unevaluated expression and evaluate with cache disabled
* Tests
  * More Python versions and passes on Travis
  * More exhaustive tests, including of new operators
  * Known bad expressions checked for raised exceptions
* Documentation
* Command line:
  * Args for forcing min and max rolls
  * Verbose outputs result breakdown
  * Module invocation (`python -m dice <options>`)
  * Use `--` to allow expressions that start with a minus sign
* Cap maximum number of dice rolled (can crash if sorting too many)
* Speed improvement for low/mid/high operators
* Tweaked drop and keep:
  * Keep (highest) is now [`^`, `h`] and drop (lowest) is [`v`, `l`]
  * Both default to n-1, which drops the single highest or lowest respectively
* Correct add even/sub odd implementation, and keep result as a vector
  * Fix for borntyping/python-dice#9
* Raise parsing exception for `d0`, as mentioned in borntyping-sandbox/diceroll#3
* Version bump and credits

Resolves #8, closes #9, and fixes #10.