### PR TITLE
Remove sudo keyword from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
       dist: xenial
-      sudo: required
     - python: 3.8-dev
       env: TOXENV=py38
       dist: xenial
-      sudo: required
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3


### PR DESCRIPTION
The `sudo` keyword is now deprecated:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration